### PR TITLE
[WLA-12068] Improved validation reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'world.betterme.translationsvalidator'
-version '1.0.8'
+version '1.1.0'
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'world.betterme.translationsvalidator'
-version '1.0.3'
+version '1.0.4'
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'world.betterme.translationsvalidator'
-version '1.0.2'
+version '1.0.3'
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'world.betterme.translationsvalidator'
-version '1.0.4'
+version '1.0.8'
 
 repositories {
     jcenter()

--- a/src/main/kotlin/world/betterme/translationsvalidator/TranslationsValidatorExtension.kt
+++ b/src/main/kotlin/world/betterme/translationsvalidator/TranslationsValidatorExtension.kt
@@ -5,6 +5,5 @@ import org.gradle.api.provider.Property
 
 open class TranslationsValidatorExtension(project: Project) {
     val resourcesPath: Property<String> = project.objects.property(String::class.java)
-    val reportToSlack: Property<String> = project.objects.property(String::class.java)
     val slackWebHook: Property<String> = project.objects.property(String::class.java)
 }

--- a/src/main/kotlin/world/betterme/translationsvalidator/ValidateTranslationsTask.kt
+++ b/src/main/kotlin/world/betterme/translationsvalidator/ValidateTranslationsTask.kt
@@ -22,6 +22,11 @@ open class ValidateTranslationsTask : DefaultTask() {
         .property(Boolean::class.java)
         .convention(false)
 
+    @Input
+    @Optional
+    val reportPayload: Property<String> = project.objects
+        .property(String::class.java)
+
     init {
         description =
             "Validates placeholders from translated strings.xml files by comparing them with main strings.xml file"
@@ -33,13 +38,19 @@ open class ValidateTranslationsTask : DefaultTask() {
         this.reportToSlack.set(reportToSlack)
     }
 
+    @Option(option = "reportPayload", description = "Will add additional payload to slack report")
+    fun setReportPayload(reportPayload: String) {
+        this.reportPayload.set(reportPayload)
+    }
+
     @Suppress("unused")
     @TaskAction
     fun validatePlaceholders() {
         val translationsValidator = TranslationsValidator.create(
             resourcesPath = resourcesPath.get(),
             shouldReportToSlack = reportToSlack.get(),
-            slackWebHook = slackWebHook.get()
+            slackWebHook = slackWebHook.get(),
+            reportPayload = reportPayload.get()
         )
         translationsValidator.validateAll()
     }

--- a/src/main/kotlin/world/betterme/translationsvalidator/ValidateTranslationsTask.kt
+++ b/src/main/kotlin/world/betterme/translationsvalidator/ValidateTranslationsTask.kt
@@ -24,7 +24,7 @@ open class ValidateTranslationsTask : DefaultTask() {
 
     @Input
     @Optional
-    val reportPayload: Property<String> = project.objects
+    val reportPayload: Property<String?> = project.objects
         .property(String::class.java)
 
     init {
@@ -50,7 +50,7 @@ open class ValidateTranslationsTask : DefaultTask() {
             resourcesPath = resourcesPath.get(),
             shouldReportToSlack = reportToSlack.get(),
             slackWebHook = slackWebHook.get(),
-            reportPayload = reportPayload.get()
+            reportPayload = reportPayload.orNull
         )
         translationsValidator.validateAll()
     }

--- a/src/main/kotlin/world/betterme/translationsvalidator/core/IssuesReporter.kt
+++ b/src/main/kotlin/world/betterme/translationsvalidator/core/IssuesReporter.kt
@@ -19,14 +19,14 @@ class IssuesReporter(
         validationErrors: List<ValidationError>,
     ): String {
         return buildString {
-            appendLine("Translation validation issues:")
+            appendLine("Placeholder validation issues for translation keys:")
             appendLine()
 
             // Grouping errors by keys
             val groupedErrors = validationErrors.groupBy { it.key }
 
             for ((key, errors) in groupedErrors) {
-                appendLine("Key `$key` issues:")
+                appendLine("`$key`:")
 
                 // Grouping errors by issue type
                 val issuesByType = errors.groupBy { it.type.id }
@@ -48,7 +48,7 @@ class IssuesReporter(
 
                     val placeholdersString = placeholders.joinToString(", ")
                     val localesString = localeMap[IssueType.Syntax.ID]?.distinct()?.joinToString(", ").orEmpty()
-                    appendLine("    - syntax issues with placeholder: $placeholdersString in locales:")
+                    appendLine("    - syntax error: $placeholdersString in locales:")
                     appendLine("      $localesString")
                 }
 
@@ -89,7 +89,7 @@ class IssuesReporter(
                     countMismatchMap.forEach { (key, locales) ->
                         val (expected, actual) = key.split("_")
                         val localesString = locales.distinct().joinToString(", ")
-                        appendLine("    - count mismatch. Expected $expected placeholders, found $actual in locales:")
+                        appendLine("    - count mismatch. Expected $expected, found $actual in locales:")
                         appendLine("      $localesString")
                     }
                 }

--- a/src/main/kotlin/world/betterme/translationsvalidator/core/IssuesReporter.kt
+++ b/src/main/kotlin/world/betterme/translationsvalidator/core/IssuesReporter.kt
@@ -1,0 +1,78 @@
+package world.betterme.translationsvalidator.core
+
+class IssuesReporter(
+    private val notifier: SlackNotifier,
+    private val shouldReportToSlack: Boolean,
+    private val reportPayload: String?
+) {
+    fun report(validationErrors: List<ValidationError>) {
+        if (validationErrors.isNotEmpty()) {
+            val report = buildReport(validationErrors)
+            println(report)
+            if (shouldReportToSlack) notifier.sendSlackMessage(report)
+        } else {
+            println("All translations validated successfully!")
+        }
+    }
+
+    private fun buildReport(
+        validationErrors: List<ValidationError>,
+    ): String {
+        return buildString {
+            appendLine("Translation validation issues:")
+            appendLine()
+
+            // Grouping errors by keys and locales
+            val groupedErrors = validationErrors.groupBy { it.key }
+
+            for ((key, errors) in groupedErrors) {
+                appendLine("Key `$key` issues:")
+
+                // Grouping errors by locale
+                val errorsByLocale = errors.groupBy { it.locale }
+                for ((locale, localeErrors) in errorsByLocale) {
+                    appendLine("  Locale: `$locale`")
+
+                    // Collecting and categorizing error messages
+                    val syntaxIssues = localeErrors.filter { it.type is IssueType.Syntax }
+                    val typeMismatches = localeErrors.filter { it.type is IssueType.Type }
+                    val countMismatches = localeErrors.filter { it.type is IssueType.Count }
+
+                    // Reporting syntax issues
+                    if (syntaxIssues.isNotEmpty()) {
+                        val placeholders = syntaxIssues.flatMap {
+                            (it.type as IssueType.Syntax).placeholders
+                        }
+                        appendLine(
+                            "    - syntax issues with placeholders: ${
+                                placeholders.joinToString(
+                                    ", "
+                                )
+                            }"
+                        )
+                    }
+
+                    // Reporting type mismatches
+                    for (typeMismatch in typeMismatches) {
+                        val errorType = typeMismatch.type as IssueType.Type
+                        appendLine("    - type mismatch at position ${errorType.position}. Expected ${errorType.expected}, found ${errorType.actual}.")
+                    }
+
+                    // Reporting count mismatches
+                    for (countMismatch in countMismatches) {
+                        val errorType = countMismatch.type as IssueType.Count
+                        appendLine("    - count mismatch. Expected ${errorType.expected} placeholders, found ${errorType.actual}.")
+                    }
+                }
+
+                appendLine()
+            }
+
+            // Including additional report payload if provided
+            if (!reportPayload.isNullOrEmpty()) {
+                appendLine(reportPayload)
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/world/betterme/translationsvalidator/core/TranslationsValidator.kt
+++ b/src/main/kotlin/world/betterme/translationsvalidator/core/TranslationsValidator.kt
@@ -130,19 +130,22 @@ class TranslationsValidator(
 
     private fun findIncorrectPlaceholders(text: String): List<String> {
         return incorrectPlaceholders.flatMap { pattern ->
-            pattern.toRegex().findAll(text).map { it.value }.toList()
+            pattern.toRegex().findAll(text).mapNotNull {
+                //exclude time formats
+                if (!it.value.contains("%\\d\\d[s,d]".toRegex())) it.value else null
+            }.toList()
         }
     }
 
     private val incorrectPlaceholders = listOf(
-        """%\d+[a-zA-Z]""",           // %1s (no $)
-        """%\d+\$\s+[a-zA-Z]""",      // %1$ s (space between $ and type)
-        """%\d+\$\d+""",              // %1$2 (invalid position after $)
-        """%[a-zA-Z]+\$""",           // %s$ (invalid at end)
-        """%\s+[a-zA-Z]""",           // % s (space between % and type)
-        """%\d+\s+\$\w""",            // %1 $s (space between number and $)
-        """%\${'$'}s+""",             // %$s (invalid position)
-        """ \${'$'}s+ """,            // $s (no %)
+        """%\d+[s,d]""",           // %1s (no $)
+        """%\d+\$\s+[s,d]""",      // %1$ s (space between $ and type)
+        """%\d+\$\d+""",           // %1$2 (invalid position after $)
+        """%[s, d]+\$""",          // %s$ (invalid at end)
+        """%\s+[s, d] """,          // % s (space between % and type)
+        """%\d+\s+\$\w""",         // %1 $s (space between number and $)
+        """%\${'$'}s+""",          // %$s (invalid position)
+        """ \${'$'}s+ """,         // $s (no %)
     )
 
     companion object Factory {

--- a/src/main/kotlin/world/betterme/translationsvalidator/core/TranslationsValidator.kt
+++ b/src/main/kotlin/world/betterme/translationsvalidator/core/TranslationsValidator.kt
@@ -6,11 +6,18 @@ import java.util.Locale
 
 typealias Resources = Map<String, String>
 
+data class ValidationError(val key: String, val locale: Locale, val type: IssueType)
+
+sealed interface IssueType {
+    data class Count(val expected: Int, val actual: Int) : IssueType
+    data class Type(val position: Int, val expected: String, val actual: String) : IssueType
+    data class Syntax(val placeholders: List<String>) : IssueType
+}
+
 class TranslationsValidator(
     private val store: TranslationsLocalStore,
     private val xmlParser: XmlParser,
-    private val notifier: SlackNotifier,
-    private val shouldReportToSlack: Boolean,
+    private val issuesReporter: IssuesReporter
 ) {
 
     fun validateAll() {
@@ -32,7 +39,7 @@ class TranslationsValidator(
         val referenceTranslation = translations[referenceLocale]
             ?: throw IllegalArgumentException("Reference locale $referenceLocale is missing.")
 
-        val validationErrors = mutableListOf<String>()
+        val validationErrors = mutableListOf<ValidationError>()
         translations.forEach { (locale, translationStrings) ->
             translationStrings.forEach { (key, localizedText) ->
                 val referenceText = referenceTranslation[key]
@@ -48,14 +55,7 @@ class TranslationsValidator(
             }
         }
 
-        if (validationErrors.isNotEmpty()) {
-            val report = validationErrors.joinToString(separator = "\n")
-            val msg = "Translation validation issues:\n$report"
-            println(msg)
-            if (shouldReportToSlack) notifier.sendSlackMessage(msg)
-        } else {
-            println("All translations validated successfully!")
-        }
+        issuesReporter.report(validationErrors)
     }
 
     private fun validatePlaceholders(
@@ -63,7 +63,7 @@ class TranslationsValidator(
         localizedText: String,
         locale: Locale,
         key: String,
-        validationErrors: MutableList<String>
+        validationErrors: MutableList<ValidationError>
     ) {
         val referencePlaceholders = extractPlaceholdersFromText(referenceText)
         val localizedPlaceholders = extractPlaceholdersFromText(localizedText)
@@ -71,7 +71,14 @@ class TranslationsValidator(
         // Validate placeholder count
         if (referencePlaceholders.size != localizedPlaceholders.size) {
             validationErrors.add(
-                "Placeholder count mismatch for key '$key' in locale '$locale'. " + "Expected ${referencePlaceholders.size}, found ${localizedPlaceholders.size}."
+                ValidationError(
+                    key = key,
+                    locale = locale,
+                    type = IssueType.Count(
+                        expected = referencePlaceholders.size,
+                        actual = localizedPlaceholders.size
+                    ),
+                )
             )
         }
 
@@ -80,10 +87,29 @@ class TranslationsValidator(
             val localizedPlaceholder = localizedPlaceholders.getOrNull(index) ?: return@forEachIndexed
             if (referencePlaceholder != localizedPlaceholder) {
                 validationErrors.add(
-                    "Placeholder type mismatch for key '$key' in locale '$locale' at position $index. " +
-                            "Expected $referencePlaceholder, found $localizedPlaceholder."
+                    ValidationError(
+                        key = key,
+                        locale = locale,
+                        type = IssueType.Type(
+                            expected = referencePlaceholder,
+                            actual = localizedPlaceholder,
+                            position = index
+                        ),
+                    )
                 )
             }
+        }
+
+        // Validate placeholder syntax
+        val incorrectPlaceholders = findIncorrectPlaceholders(localizedText)
+        if (incorrectPlaceholders.isNotEmpty()) {
+            validationErrors.add(
+                ValidationError(
+                    key = key,
+                    locale = locale,
+                    type = IssueType.Syntax(incorrectPlaceholders),
+                )
+            )
         }
     }
 
@@ -102,22 +128,40 @@ class TranslationsValidator(
             .toList()
     }
 
+    private fun findIncorrectPlaceholders(text: String): List<String> {
+        return incorrectPlaceholders.flatMap { pattern ->
+            pattern.toRegex().findAll(text).map { it.value }.toList()
+        }
+    }
+
+    private val incorrectPlaceholders = listOf(
+        """%\d+[a-zA-Z]""",           // %1s (no $)
+        """%\d+\$\s+[a-zA-Z]""",      // %1$ s (space between $ and type)
+        """%\d+\$\d+""",              // %1$2 (invalid position after $)
+        """%[a-zA-Z]+\$""",           // %s$ (invalid at end)
+        """%\s+[a-zA-Z]""",           // % s (space between % and type)
+        """%\d+\s+\$\w""",            // %1 $s (space between number and $)
+        """%\${'$'}s+""",             // %$s (invalid position)
+        """ \${'$'}s+ """,            // $s (no %)
+    )
+
     companion object Factory {
 
         @JvmStatic
         fun create(
             resourcesPath: String,
             shouldReportToSlack: Boolean,
-            slackWebHook: String
+            slackWebHook: String,
+            reportPayload: String?
         ): TranslationsValidator {
             val store = TranslationsLocalStoreImpl(resourcesPath)
             val parser = XmlParser()
             val notifier = SlackNotifier(slackWebHook)
+            val issuesReporter = IssuesReporter(notifier, shouldReportToSlack, reportPayload)
             return TranslationsValidator(
                 store = store,
                 xmlParser = parser,
-                notifier = notifier,
-                shouldReportToSlack = shouldReportToSlack
+                issuesReporter = issuesReporter,
             )
         }
     }

--- a/src/main/kotlin/world/betterme/translationsvalidator/core/TranslationsValidator.kt
+++ b/src/main/kotlin/world/betterme/translationsvalidator/core/TranslationsValidator.kt
@@ -8,10 +8,25 @@ typealias Resources = Map<String, String>
 
 data class ValidationError(val key: String, val locale: Locale, val type: IssueType)
 
-sealed interface IssueType {
-    data class Count(val expected: Int, val actual: Int) : IssueType
-    data class Type(val position: Int, val expected: String, val actual: String) : IssueType
-    data class Syntax(val placeholders: List<String>) : IssueType
+sealed class IssueType(val id: Int) {
+
+    data class Count(val expected: Int, val actual: Int) : IssueType(ID) {
+        companion object {
+            const val ID = 0
+        }
+    }
+
+    data class Type(val position: Int, val expected: String, val actual: String) : IssueType(ID) {
+        companion object {
+            const val ID = 1
+        }
+    }
+
+    data class Syntax(val placeholders: List<String>) : IssueType(ID) {
+        companion object {
+            const val ID = 2
+        }
+    }
 }
 
 class TranslationsValidator(

--- a/src/test/kotlin/world/betterme/translationsvalidator/core/IssuesReporterTest.kt
+++ b/src/test/kotlin/world/betterme/translationsvalidator/core/IssuesReporterTest.kt
@@ -36,18 +36,18 @@ class IssuesReporterTest {
 
         issuesReporter.report(errors)
 
-        val expectedReport = "Translation validation issues:\n" +
+        val expectedReport = "Placeholder validation issues for translation keys:\n" +
                 "\n" +
-                "Key `key1` issues:\n" +
-                "    - count mismatch. Expected 2 placeholders, found 1 in locales:\n" +
+                "`key1`:\n" +
+                "    - count mismatch. Expected 2, found 1 in locales:\n" +
                 "      `en`\n" +
                 "\n" +
-                "Key `key2` issues:\n" +
+                "`key2`:\n" +
                 "    - type mismatch at position 0. Expected %s, found %d in locales:\n" +
                 "      `en`\n" +
                 "\n" +
-                "Key `key3` issues:\n" +
-                "    - syntax issues with placeholder: \$s, %1 \$s in locales:\n" +
+                "`key3`:\n" +
+                "    - syntax error: \$s, %1 \$s in locales:\n" +
                 "      `en`\n" +
                 "\n" +
                 "Author: AMayst\n"

--- a/src/test/kotlin/world/betterme/translationsvalidator/core/IssuesReporterTest.kt
+++ b/src/test/kotlin/world/betterme/translationsvalidator/core/IssuesReporterTest.kt
@@ -39,16 +39,16 @@ class IssuesReporterTest {
         val expectedReport = "Translation validation issues:\n" +
                 "\n" +
                 "Key `key1` issues:\n" +
-                "  Locale: `en`\n" +
-                "    - count mismatch. Expected 2 placeholders, found 1.\n" +
+                "    - count mismatch. Expected 2 placeholders, found 1 in locales:\n" +
+                "      `en`\n" +
                 "\n" +
                 "Key `key2` issues:\n" +
-                "  Locale: `en`\n" +
-                "    - type mismatch at position 0. Expected %s, found %d.\n" +
+                "    - type mismatch at position 0. Expected %s, found %d in locales:\n" +
+                "      `en`\n" +
                 "\n" +
                 "Key `key3` issues:\n" +
-                "  Locale: `en`\n" +
-                "    - syntax issues with placeholders: \$s, %1 \$s\n" +
+                "    - syntax issues with placeholder: \$s, %1 \$s in locales:\n" +
+                "      `en`\n" +
                 "\n" +
                 "Author: AMayst\n"
 

--- a/src/test/kotlin/world/betterme/translationsvalidator/core/IssuesReporterTest.kt
+++ b/src/test/kotlin/world/betterme/translationsvalidator/core/IssuesReporterTest.kt
@@ -1,0 +1,78 @@
+package world.betterme.translationsvalidator.core
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+class IssuesReporterTest {
+
+    private val notifier = mockk<SlackNotifier>(relaxed = true)
+
+    @Test
+    fun `should correct build and send report`() {
+        val issuesReporter = IssuesReporter(
+            notifier = notifier,
+            shouldReportToSlack = true,
+            reportPayload = "Author: AMayst"
+        )
+        val errors = listOf(
+            ValidationError(
+                key = "key1",
+                locale = Locale.ENGLISH,
+                type = IssueType.Count(2, 1)
+            ),
+            ValidationError(
+                key = "key2",
+                locale = Locale.ENGLISH,
+                type = IssueType.Type(0, "%s", "%d")
+            ),
+            ValidationError(
+                key = "key3",
+                locale = Locale.ENGLISH,
+                type = IssueType.Syntax(listOf("\$s", "%1 \$s"))
+            )
+        )
+
+        issuesReporter.report(errors)
+
+        val expectedReport = "Translation validation issues:\n" +
+                "\n" +
+                "Key `key1` issues:\n" +
+                "  Locale: `en`\n" +
+                "    - count mismatch. Expected 2 placeholders, found 1.\n" +
+                "\n" +
+                "Key `key2` issues:\n" +
+                "  Locale: `en`\n" +
+                "    - type mismatch at position 0. Expected %s, found %d.\n" +
+                "\n" +
+                "Key `key3` issues:\n" +
+                "  Locale: `en`\n" +
+                "    - syntax issues with placeholders: \$s, %1 \$s\n" +
+                "\n" +
+                "Author: AMayst\n"
+
+        verify { notifier.sendSlackMessage(expectedReport) }
+    }
+
+    @Test
+    fun `should not send report if shouldReportToSlack false`() {
+        val issuesReporter = IssuesReporter(
+            notifier = notifier,
+            shouldReportToSlack = false,
+            reportPayload = null
+        )
+        val errors = listOf(
+            ValidationError(
+                key = "key1",
+                locale = Locale.ENGLISH,
+                type = IssueType.Count(2, 1)
+            )
+        )
+
+        issuesReporter.report(errors)
+
+        verify(exactly = 0) { notifier.sendSlackMessage(any()) }
+    }
+
+}

--- a/src/test/kotlin/world/betterme/translationsvalidator/data/TranslationsValidatorTest.kt
+++ b/src/test/kotlin/world/betterme/translationsvalidator/data/TranslationsValidatorTest.kt
@@ -61,8 +61,8 @@ class TranslationsValidatorTest {
                 "Translation validation issues:\n" +
                         "\n" +
                         "Key `hello` issues:\n" +
-                        "  Locale: `fr`\n" +
-                        "    - count mismatch. Expected 2 placeholders, found 1.\n" +
+                        "    - count mismatch. Expected 2 placeholders, found 1 in locales:\n" +
+                        "      `fr`\n" +
                         "\n" +
                         "PR: Validation plugin \n" +
                         "Author: AMayst\n"
@@ -91,8 +91,8 @@ class TranslationsValidatorTest {
                 it == "Translation validation issues:\n" +
                         "\n" +
                         "Key `hello` issues:\n" +
-                        "  Locale: `fr`\n" +
-                        "    - type mismatch at position 0. Expected %1\$s, found %1\$d.\n" +
+                        "    - type mismatch at position 0. Expected %1\$s, found %1\$d in locales:\n" +
+                        "      `fr`\n" +
                         "\n" +
                         "PR: Validation plugin \n" +
                         "Author: AMayst\n"
@@ -140,72 +140,60 @@ class TranslationsValidatorTest {
                 it == "Translation validation issues:\n" +
                         "\n" +
                         "Key `error1` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %3s\n" +
-                        "  Locale: `fr`\n" +
-                        "    - syntax issues with placeholders: %3s\n" +
+                        "    - syntax issues with placeholder: %3s in locales:\n" +
+                        "      `en`, `fr`\n" +
                         "\n" +
                         "Key `error2` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %1\$ s\n" +
-                        "  Locale: `fr`\n" +
-                        "    - syntax issues with placeholders: %1\$ s\n" +
+                        "    - syntax issues with placeholder: %1\$ s in locales:\n" +
+                        "      `en`, `fr`\n" +
                         "\n" +
                         "Key `error3` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %s\$\n" +
-                        "  Locale: `fr`\n" +
-                        "    - syntax issues with placeholders: %s\$\n" +
+                        "    - syntax issues with placeholder: %s\$ in locales:\n" +
+                        "      `en`, `fr`\n" +
                         "\n" +
                         "Key `error5` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %1 \$s\n" +
-                        "  Locale: `fr`\n" +
-                        "    - syntax issues with placeholders: %1 \$s\n" +
+                        "    - syntax issues with placeholder: %1 \$s in locales:\n" +
+                        "      `en`, `fr`\n" +
                         "\n" +
                         "Key `error6` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %\$s\n" +
-                        "  Locale: `fr`\n" +
-                        "    - syntax issues with placeholders: %\$s\n" +
+                        "    - syntax issues with placeholder: %\$s in locales:\n" +
+                        "      `en`, `fr`\n" +
                         "\n" +
                         "Key `error7` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %\$s\n" +
-                        "  Locale: `fr`\n" +
-                        "    - syntax issues with placeholders: %\$s\n" +
+                        "    - syntax issues with placeholder: %\$s in locales:\n" +
+                        "      `en`, `fr`\n" +
                         "\n" +
                         "Key `error8` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %3s\n" +
+                        "    - syntax issues with placeholder: %3s in locales:\n" +
+                        "      `en`\n" +
                         "\n" +
                         "Key `error9` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %1\$ s\n" +
+                        "    - syntax issues with placeholder: %1\$ s in locales:\n" +
+                        "      `en`\n" +
                         "\n" +
                         "Key `error10` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %1\$2\n" +
+                        "    - syntax issues with placeholder: %1\$2 in locales:\n" +
+                        "      `en`\n" +
                         "\n" +
                         "Key `error11` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %s\$\n" +
+                        "    - syntax issues with placeholder: %s\$ in locales:\n" +
+                        "      `en`\n" +
                         "\n" +
                         "Key `error12` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: % s \n" +
+                        "    - syntax issues with placeholder: % s  in locales:\n" +
+                        "      `en`\n" +
                         "\n" +
                         "Key `error13` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %1 \$s,  \$s \n" +
+                        "    - syntax issues with placeholder: %1 \$s,  \$s  in locales:\n" +
+                        "      `en`\n" +
                         "\n" +
                         "Key `error14` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %\$s\n" +
+                        "    - syntax issues with placeholder: %\$s in locales:\n" +
+                        "      `en`\n" +
                         "\n" +
                         "Key `error15` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: %\$s\n" +
+                        "    - syntax issues with placeholder: %\$s in locales:\n" +
+                        "      `en`\n" +
                         "\n" +
                         "PR: Validation plugin \n" +
                         "Author: AMayst\n"

--- a/src/test/kotlin/world/betterme/translationsvalidator/data/TranslationsValidatorTest.kt
+++ b/src/test/kotlin/world/betterme/translationsvalidator/data/TranslationsValidatorTest.kt
@@ -157,12 +157,6 @@ class TranslationsValidatorTest {
                         "  Locale: `fr`\n" +
                         "    - syntax issues with placeholders: %s\$\n" +
                         "\n" +
-                        "Key `error4` issues:\n" +
-                        "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: % s\n" +
-                        "  Locale: `fr`\n" +
-                        "    - syntax issues with placeholders: % s\n" +
-                        "\n" +
                         "Key `error5` issues:\n" +
                         "  Locale: `en`\n" +
                         "    - syntax issues with placeholders: %1 \$s\n" +
@@ -199,7 +193,7 @@ class TranslationsValidatorTest {
                         "\n" +
                         "Key `error12` issues:\n" +
                         "  Locale: `en`\n" +
-                        "    - syntax issues with placeholders: % s\n" +
+                        "    - syntax issues with placeholders: % s \n" +
                         "\n" +
                         "Key `error13` issues:\n" +
                         "  Locale: `en`\n" +

--- a/src/test/kotlin/world/betterme/translationsvalidator/data/TranslationsValidatorTest.kt
+++ b/src/test/kotlin/world/betterme/translationsvalidator/data/TranslationsValidatorTest.kt
@@ -58,10 +58,10 @@ class TranslationsValidatorTest {
         verify { store.getFiles() }
         verify {
             notifier.sendSlackMessage(
-                "Translation validation issues:\n" +
+                "Placeholder validation issues for translation keys:\n" +
                         "\n" +
-                        "Key `hello` issues:\n" +
-                        "    - count mismatch. Expected 2 placeholders, found 1 in locales:\n" +
+                        "`hello`:\n" +
+                        "    - count mismatch. Expected 2, found 1 in locales:\n" +
                         "      `fr`\n" +
                         "\n" +
                         "PR: Validation plugin \n" +
@@ -88,9 +88,9 @@ class TranslationsValidatorTest {
         verify { store.getFiles() }
         verify {
             notifier.sendSlackMessage(match {
-                it == "Translation validation issues:\n" +
+                it == "Placeholder validation issues for translation keys:\n" +
                         "\n" +
-                        "Key `hello` issues:\n" +
+                        "`hello`:\n" +
                         "    - type mismatch at position 0. Expected %1\$s, found %1\$d in locales:\n" +
                         "      `fr`\n" +
                         "\n" +
@@ -137,62 +137,62 @@ class TranslationsValidatorTest {
         verify { store.getFiles() }
         verify {
             notifier.sendSlackMessage(match {
-                it == "Translation validation issues:\n" +
+                it == "Placeholder validation issues for translation keys:\n" +
                         "\n" +
-                        "Key `error1` issues:\n" +
-                        "    - syntax issues with placeholder: %3s in locales:\n" +
+                        "`error1`:\n" +
+                        "    - syntax error: %3s in locales:\n" +
                         "      `en`, `fr`\n" +
                         "\n" +
-                        "Key `error2` issues:\n" +
-                        "    - syntax issues with placeholder: %1\$ s in locales:\n" +
+                        "`error2`:\n" +
+                        "    - syntax error: %1\$ s in locales:\n" +
                         "      `en`, `fr`\n" +
                         "\n" +
-                        "Key `error3` issues:\n" +
-                        "    - syntax issues with placeholder: %s\$ in locales:\n" +
+                        "`error3`:\n" +
+                        "    - syntax error: %s\$ in locales:\n" +
                         "      `en`, `fr`\n" +
                         "\n" +
-                        "Key `error5` issues:\n" +
-                        "    - syntax issues with placeholder: %1 \$s in locales:\n" +
+                        "`error5`:\n" +
+                        "    - syntax error: %1 \$s in locales:\n" +
                         "      `en`, `fr`\n" +
                         "\n" +
-                        "Key `error6` issues:\n" +
-                        "    - syntax issues with placeholder: %\$s in locales:\n" +
+                        "`error6`:\n" +
+                        "    - syntax error: %\$s in locales:\n" +
                         "      `en`, `fr`\n" +
                         "\n" +
-                        "Key `error7` issues:\n" +
-                        "    - syntax issues with placeholder: %\$s in locales:\n" +
+                        "`error7`:\n" +
+                        "    - syntax error: %\$s in locales:\n" +
                         "      `en`, `fr`\n" +
                         "\n" +
-                        "Key `error8` issues:\n" +
-                        "    - syntax issues with placeholder: %3s in locales:\n" +
+                        "`error8`:\n" +
+                        "    - syntax error: %3s in locales:\n" +
                         "      `en`\n" +
                         "\n" +
-                        "Key `error9` issues:\n" +
-                        "    - syntax issues with placeholder: %1\$ s in locales:\n" +
+                        "`error9`:\n" +
+                        "    - syntax error: %1\$ s in locales:\n" +
                         "      `en`\n" +
                         "\n" +
-                        "Key `error10` issues:\n" +
-                        "    - syntax issues with placeholder: %1\$2 in locales:\n" +
+                        "`error10`:\n" +
+                        "    - syntax error: %1\$2 in locales:\n" +
                         "      `en`\n" +
                         "\n" +
-                        "Key `error11` issues:\n" +
-                        "    - syntax issues with placeholder: %s\$ in locales:\n" +
+                        "`error11`:\n" +
+                        "    - syntax error: %s\$ in locales:\n" +
                         "      `en`\n" +
                         "\n" +
-                        "Key `error12` issues:\n" +
-                        "    - syntax issues with placeholder: % s  in locales:\n" +
+                        "`error12`:\n" +
+                        "    - syntax error: % s  in locales:\n" +
                         "      `en`\n" +
                         "\n" +
-                        "Key `error13` issues:\n" +
-                        "    - syntax issues with placeholder: %1 \$s,  \$s  in locales:\n" +
+                        "`error13`:\n" +
+                        "    - syntax error: %1 \$s,  \$s  in locales:\n" +
                         "      `en`\n" +
                         "\n" +
-                        "Key `error14` issues:\n" +
-                        "    - syntax issues with placeholder: %\$s in locales:\n" +
+                        "`error14`:\n" +
+                        "    - syntax error: %\$s in locales:\n" +
                         "      `en`\n" +
                         "\n" +
-                        "Key `error15` issues:\n" +
-                        "    - syntax issues with placeholder: %\$s in locales:\n" +
+                        "`error15`:\n" +
+                        "    - syntax error: %\$s in locales:\n" +
                         "      `en`\n" +
                         "\n" +
                         "PR: Validation plugin \n" +

--- a/src/test/resources/syntax_issues/value-fr/strings.xml
+++ b/src/test/resources/syntax_issues/value-fr/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="error1">Bonjour %3s</string>
+    <string name="error2">Bonjour %1$ s</string>
+    <string name="error3">Bonjour %1$2</string>
+    <string name="error3">Bonjour %s$</string>
+    <string name="error4">Bonjour % s</string>
+    <string name="error5">Bonjour %1 $s</string>
+    <string name="error6">Bonjour %$s</string>
+    <string name="error7">Bonjour %$s</string>
+</resources>

--- a/src/test/resources/syntax_issues/value/strings.xml
+++ b/src/test/resources/syntax_issues/value/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="error1">Hello %3s</string>
+    <string name="error2">Hello %1$ s</string>
+    <string name="error3">Hello %1$2</string>
+    <string name="error3">Hello %s$</string>
+    <string name="error4">Hello % s</string>
+    <string name="error5">Hello %1 $s</string>
+    <string name="error6">Hello %$s</string>
+    <string name="error7">Hello %$s</string>
+
+    <string name="error8">Hello %3s error</string>
+    <string name="error9">Hello %1$ s error</string>
+    <string name="error10">Hello %1$2 error</string>
+    <string name="error11">Hello %s$ error</string>
+    <string name="error12">Hello % s error</string>
+    <string name="error13">Hello %1 $s error</string>
+    <string name="error14">Hello %$s error</string>
+    <string name="error15">Hello %$s error</string>
+</resources>


### PR DESCRIPTION
Task: [WLA-12068](https://newsiteam.atlassian.net/browse/WLA-12068)

Що було зроблено: 
- додав до репорту лінку на PR, в якому плагін знайшов проблеми з рядками для оперативного усунення
- додав перевірку неправильного написання плейсхолдерів. Раніше плагін перевіряв тільки кількість плейсхолдерів в всіх файлах локалізації. Проте якщо у всіх файлах написати неправильно плейсхолдер то валідатор не відловить проблему
- покращив структуру репорта, видалив дублікати, щоб локалізаторам було простіше виправляти помилки

Було: 
<img width="1055" alt="image" src="https://github.com/user-attachments/assets/b9631b42-ee6a-4d8a-a092-9befad051ea2">
Стало: 
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/8d882731-3998-4637-a9fa-58c776af0116">


[WLA-12068]: https://newsiteam.atlassian.net/browse/WLA-12068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ